### PR TITLE
Analysis agent

### DIFF
--- a/web/src/app/match/[eventId]/page.tsx
+++ b/web/src/app/match/[eventId]/page.tsx
@@ -18,6 +18,7 @@ import MatchSummaryCard from "@/components/match/MatchSummaryCard";
 import WinProbabilityCard from "@/components/match/WinProbabilityCard";
 
 import { buildTimeline, computeLeaders, computeBestPlayer } from "@/lib/match-mappers";
+import { LeagueStandingsCard } from "@/components/league/LeagueStandingsCard";
 import type { TLItem } from "@/lib/match-mappers";
 import {
   getEventResults,
@@ -828,7 +829,7 @@ export default function MatchPage() {
         }
 
         if (tableData.length > 0) {
-          const mapped = tableData.slice(0, 12).map((r, index) => {
+          const mapped = tableData.map((r, index) => {
             const rec = r as Record<string, unknown>;
             const position = typeof rec.position === "number" ? rec.position :
               typeof rec.rank === "number" ? rec.rank :
@@ -838,7 +839,7 @@ export default function MatchPage() {
             // Use all possible team name fields, including 'standing_team'
             const teamName = pickString(rec, ["team", "team_name", "name", "standing_team"]);
 
-            // Extract league table data using the same fields as the old implementation
+            // Extract league table data using the correct fields for this API
             const played = parseNumber(rec.standing_P) ??
               parseNumber(rec.overall_league_payed) ??
               parseNumber(rec.overall_league_played) ??
@@ -861,15 +862,19 @@ export default function MatchPage() {
               parseNumber(rec.losses) ??
               parseNumber(rec.L) ?? 0;
 
-            const goalsFor = parseNumber(rec.goals_for) ??
+            // Updated mappings for GF, GA, GD
+            const goalsFor = parseNumber(rec.standing_F) ??
+              parseNumber(rec.goals_for) ??
               parseNumber(rec.overall_league_GF) ??
               parseNumber(rec.GF) ?? 0;
 
-            const goalsAgainst = parseNumber(rec.goals_against) ??
+            const goalsAgainst = parseNumber(rec.standing_A) ??
+              parseNumber(rec.goals_against) ??
               parseNumber(rec.overall_league_GA) ??
               parseNumber(rec.GA) ?? 0;
 
-            const goalDifference = parseNumber(rec.goal_difference) ??
+            const goalDifference = parseNumber(rec.standing_GD) ??
+              parseNumber(rec.goal_difference) ??
               parseNumber(rec.overall_league_GD) ??
               parseNumber(rec.GD) ?? 0;
 
@@ -1300,78 +1305,22 @@ export default function MatchPage() {
 
           <TabsContent value="league" className="space-y-4">
             {table.length > 0 ? (
-              <Card className="shadow-xl border-2 border-primary/20 bg-gradient-to-br from-background to-primary/5">
-                <CardHeader>
-                  <CardTitle className="text-2xl font-bold text-primary">League Table</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="overflow-x-auto">
-                    <table className="min-w-full rounded-xl bg-background text-base text-foreground">
-                      <thead className="bg-primary/10">
-                        <tr>
-                          <th className="px-4 py-3 text-left font-semibold">#</th>
-                          <th className="px-4 py-3 text-left font-semibold">Team</th>
-                          <th className="px-4 py-3 text-left font-semibold">Played</th>
-                          <th className="px-4 py-3 text-left font-semibold">W</th>
-                          <th className="px-4 py-3 text-left font-semibold">D</th>
-                          <th className="px-4 py-3 text-left font-semibold">L</th>
-                          <th className="px-4 py-3 text-left font-semibold">GF</th>
-                          <th className="px-4 py-3 text-left font-semibold">GA</th>
-                          <th className="px-4 py-3 text-left font-semibold">GD</th>
-                          <th className="px-4 py-3 text-left font-semibold">Pts</th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {table.map((row, idx) => {
-                          // Try to get logo from teamsExtra first, fallback to row.logo or row.team_logo
-                          let logo: string | undefined = undefined;
-                          const teamName = typeof row.team === "string" ? row.team : String(row.team ?? "");
-                          const norm = (s: unknown) => typeof s === "string" ? s.trim().toLowerCase() : typeof s === "number" ? String(s).toLowerCase() : "";
-                          // Safely extract home team name
-                          const homeName = typeof teamsExtra.home?.team_name === "string" ? teamsExtra.home.team_name : typeof teamsExtra.home?.name === "string" ? teamsExtra.home.name : "";
-                          if (teamsExtra.home && norm(homeName) === norm(teamName)) {
-                            logo = typeof teamsExtra.home.logo === "string" ? teamsExtra.home.logo :
-                              typeof teamsExtra.home.team_logo === "string" ? teamsExtra.home.team_logo :
-                              typeof teamsExtra.home.badge === "string" ? teamsExtra.home.badge : undefined;
-                          } else {
-                            const awayName = typeof teamsExtra.away?.team_name === "string" ? teamsExtra.away.team_name : typeof teamsExtra.away?.name === "string" ? teamsExtra.away.name : "";
-                            if (teamsExtra.away && norm(awayName) === norm(teamName)) {
-                              logo = typeof teamsExtra.away.logo === "string" ? teamsExtra.away.logo :
-                                typeof teamsExtra.away.team_logo === "string" ? teamsExtra.away.team_logo :
-                                typeof teamsExtra.away.badge === "string" ? teamsExtra.away.badge : undefined;
-                            }
-                          }
-                          if (!logo) logo = typeof row.logo === "string" ? row.logo :
-                            typeof row.team_logo === "string" ? row.team_logo :
-                            typeof row.badge === "string" ? row.badge : undefined;
-
-                          return (
-                            <tr key={idx} className={idx < 3 ? "bg-primary/5" : idx % 2 === 0 ? "bg-background" : "bg-primary/2"}>
-                              <td className="px-4 py-3 font-bold text-lg text-primary/80">{row.position}</td>
-                              <td className="px-4 py-3 flex items-center gap-3">
-                                {logo ? (
-                                  <Image src={logo} alt={teamName} width={32} height={32} className="w-8 h-8 rounded-full border border-primary/30 bg-white object-contain" />
-                                ) : (
-                                  <span className="w-8 h-8 inline-block rounded-full bg-muted/30 border border-muted/40" />
-                                )}
-                                <span className="font-semibold text-base">{teamName}</span>
-                              </td>
-                              <td className="px-4 py-3 text-center">{row.played}</td>
-                              <td className="px-4 py-3 text-center">{row.won}</td>
-                              <td className="px-4 py-3 text-center">{row.drawn}</td>
-                              <td className="px-4 py-3 text-center">{row.lost}</td>
-                              <td className="px-4 py-3 text-center">{row.goalsFor}</td>
-                              <td className="px-4 py-3 text-center">{row.goalsAgainst}</td>
-                              <td className="px-4 py-3 text-center">{row.goalDifference}</td>
-                              <td className="px-4 py-3 text-center font-bold text-primary">{row.points}</td>
-                            </tr>
-                          );
-                        })}
-                      </tbody>
-                    </table>
-                  </div>
-                </CardContent>
-              </Card>
+              <LeagueStandingsCard
+                rows={table.map((row, idx) => ({
+                  ...row,
+                  id: typeof row.id === "string" ? row.id : `${row.team ?? "row"}-${row.position ?? idx}`,
+                }))}
+                loading={false}
+                error={null}
+                seasonOptions={[]}
+                selectedSeason={""}
+                onSelectSeason={() => {}}
+                stageOptions={[]}
+                selectedStage={""}
+                onSelectStage={() => {}}
+                lastUpdated={undefined}
+                highlightTeams={[match.homeTeam, match.awayTeam]}
+              />
             ) : extrasLoading ? (
               <Card>
                 <CardContent className="p-6">


### PR DESCRIPTION
This pull request refactors how league standings are displayed on the match page, improving both data mapping and the user interface. The main changes include replacing the custom league table rendering with the reusable `LeagueStandingsCard` component, updating data mappings for league table fields to better match the API, and enhancing the visual highlighting of the home and away teams in the standings.

**Component refactoring and UI improvements:**

* The custom league table markup in `page.tsx` was replaced with the `LeagueStandingsCard` component for a more maintainable and consistent UI across the app. The new component now receives the full table and highlights the home and away teams. (`[web/src/app/match/[eventId]/page.tsxL1303-R1323](diffhunk://#diff-13f4326d4b5a8af13e0eb01a8c0ea1867bf02e9f8ef2c6bc90d30688af40a0e3L1303-R1323)`, `[web/src/app/match/[eventId]/page.tsxR21](diffhunk://#diff-13f4326d4b5a8af13e0eb01a8c0ea1867bf02e9f8ef2c6bc90d30688af40a0e3R21)`)
* The `LeagueStandingsCard` component was updated to show the entire league table by default (removing the "Show all" button), and to visually highlight rows for the current match's home and away teams. Highlighted teams are marked with a badge and distinct styling. (`[[1]](diffhunk://#diff-bffbd7511cb2b725c1a794913cfa9f0a63a975ccfcebe82cb212876861339597R76-R79)`, `[[2]](diffhunk://#diff-bffbd7511cb2b725c1a794913cfa9f0a63a975ccfcebe82cb212876861339597L135-L190)`)

**Data mapping and API compatibility:**

* The mapping logic for league table rows in `page.tsx` was updated to use all available rows (not just the top 12), and to extract team names and statistics using API-specific fields for better compatibility. (`[web/src/app/match/[eventId]/page.tsxL831-R832](diffhunk://#diff-13f4326d4b5a8af13e0eb01a8c0ea1867bf02e9f8ef2c6bc90d30688af40a0e3L831-R832)`, `[web/src/app/match/[eventId]/page.tsxL841-R842](diffhunk://#diff-13f4326d4b5a8af13e0eb01a8c0ea1867bf02e9f8ef2c6bc90d30688af40a0e3L841-R842)`)
* Mappings for goals for, goals against, and goal difference now use updated field names (`standing_F`, `standing_A`, `standing_GD`) to match the API response, with fallbacks for older field names. (`[web/src/app/match/[eventId]/page.tsxL864-R877](diffhunk://#diff-13f4326d4b5a8af13e0eb01a8c0ea1867bf02e9f8ef2c6bc90d30688af40a0e3L864-R877)`)
* The `StandingRow` type in `LeagueStandingsCard.tsx` was extended to include raw API fields for fallback mapping, improving robustness against varying API responses. (`[web/src/components/league/LeagueStandingsCard.tsxR20-R36](diffhunk://#diff-bffbd7511cb2b725c1a794913cfa9f0a63a975ccfcebe82cb212876861339597R20-R36)`)

**Minor improvements:**

* Table column widths and alignment were adjusted for improved readability, and the "Form" column is now conditionally rendered only if data is present. (`[web/src/components/league/LeagueStandingsCard.tsxL135-L190](diffhunk://#diff-bffbd7511cb2b725c1a794913cfa9f0a63a975ccfcebe82cb212876861339597L135-L190)`)

These changes collectively improve maintainability, API compatibility, and the user experience of the league standings feature.