### PR TITLE
refactor: remove LeagueLatestNews component from LeagueDetailPage

### DIFF
--- a/web/src/app/leagues/[leagueId]/page.tsx
+++ b/web/src/app/leagues/[leagueId]/page.tsx
@@ -12,7 +12,7 @@ import { getLeagueTable, listSeasons, postCollect, Json } from "@/lib/collect";
 import LeagueLiveMatches from "@/components/league/LeagueLiveMatches";
 import LeagueSeasonMatches from "@/components/league/LeagueSeasonMatches";
 import LeagueStatistics from "@/components/league/LeagueStatistics";
-import LeagueLatestNews from "@/components/league/LeagueLatestNews";
+
 
 type LeagueListEntry = {
   id?: string;
@@ -746,9 +746,6 @@ export default function LeagueDetailPage() {
         leagueName={leagueName || heroInfo?.name}
         seasonLabel={seasonLabels[selectedSeason] || selectedSeason}
       />
-
-      {/* Latest news related to this league */}
-      <LeagueLatestNews leagueName={leagueName || heroInfo?.name} />
 
     </div>
   );


### PR DESCRIPTION
This pull request makes a small change to the `LeagueDetailPage` component by removing the display of the latest news section for a league.

* The import and usage of the `LeagueLatestNews` component have been removed from `web/src/app/leagues/[leagueId]/page.tsx`, so the league detail page will no longer show the latest news related to the league. ([web/src/app/leagues/[leagueId]/page.tsxL15-R15](diffhunk://#diff-124e3bae3a70af314ce7bb1462fce310abf23fed457380c6e2149b6368485b02L15-R15), [web/src/app/leagues/[leagueId]/page.tsxL750-L752](diffhunk://#diff-124e3bae3a70af314ce7bb1462fce310abf23fed457380c6e2149b6368485b02L750-L752))