### PR TITLE
Summary agent

### DIFF
--- a/web/src/components/match/MatchSummaryCard.tsx
+++ b/web/src/components/match/MatchSummaryCard.tsx
@@ -120,7 +120,10 @@ export function MatchSummaryCard({ event, rawEvent }: MatchSummaryCardProps) {
           let raw: SummaryResponse | undefined | null = undefined;
           try {
             // Prefer safe summarizer which adds schema validation and moderation
-            const safe = await safeSummarize(payload as { eventId?: string; eventName?: string; date?: string; venue?: string; homeTeam?: string; awayTeam?: string });
+            const safe = await safeSummarize({
+              ...(payload as { eventId?: string; eventName?: string; date?: string; venue?: string; homeTeam?: string; awayTeam?: string }),
+              full: true,
+            });
             raw = { headline: safe.headline, paragraph: safe.paragraph, bullets: safe.bullets };
           } catch {
             // Keep raw undefined; we'll fall back to local summary below

--- a/web/src/lib/moderation.ts
+++ b/web/src/lib/moderation.ts
@@ -37,11 +37,18 @@ function hasWord(haystack: string, list: string[]): boolean {
   return list.some((w) => lower.includes(w));
 }
 
-export function moderateSummary(input: { headline: string; paragraph: string; bullets: string[] }): ModerationResult {
+export function moderateSummary(
+  input: { headline: string; paragraph: string; bullets: string[] },
+  options?: { clamp?: boolean }
+): ModerationResult {
+  const clamp = options?.clamp !== false;
+  const clampStr = (s: string, n: number) => (clamp ? s.slice(0, n) : s);
+  const clampArr = <T,>(arr: T[], n: number) => (clamp ? arr.slice(0, n) : arr);
+
   const cleaned = {
-    headline: scrub(input.headline).slice(0, 200),
-    paragraph: scrub(input.paragraph).slice(0, 800),
-    bullets: (Array.isArray(input.bullets) ? input.bullets : []).map((b) => scrub(String(b)).slice(0, 200)).slice(0, 5),
+    headline: clampStr(scrub(input.headline), 200),
+    paragraph: clampStr(scrub(input.paragraph), 10000),
+    bullets: clampArr((Array.isArray(input.bullets) ? input.bullets : []).map((b) => clampStr(scrub(String(b)), 1000)), 50),
   };
 
   const reasons: string[] = [];

--- a/web/src/lib/summarizeSafe.ts
+++ b/web/src/lib/summarizeSafe.ts
@@ -13,6 +13,7 @@ export async function safeSummarize(payload: {
   venue?: string;
   homeTeam?: string;
   awayTeam?: string;
+  full?: boolean;
 }): Promise<SafeSummary> {
   const r = await fetch('/api/safe-summarize', {
     method: 'POST',

--- a/web/src/lib/summarySchema.ts
+++ b/web/src/lib/summarySchema.ts
@@ -8,7 +8,7 @@ export const SummarySchema = z.object({
     .default('Match Summary'),
   paragraph: z
     .preprocess((v) => String(v ?? '').replace(/\s+/g, ' ').trim(), z.string())
-    .transform((s) => s.slice(0, 800))
+    .transform((s) => s.slice(0, 1000))
     .optional()
     .default(''),
   bullets: z
@@ -52,3 +52,17 @@ export const EMPTY_SUMMARY: Summary = {
   paragraph: '',
   bullets: [],
 };
+
+// Coerce without clamping: used when callers want the full model text.
+export function coerceSummaryLoose(input: unknown): { headline: string; paragraph: string; bullets: string[] } {
+  const shape: Record<string, unknown> =
+    typeof input === 'object' && input !== null ? (input as Record<string, unknown>) : {};
+
+  const getStr = (v: unknown) => (typeof v === 'string' ? v : v == null ? '' : String(v));
+  const bulletsRaw = Array.isArray((shape as any).bullets) ? ((shape as any).bullets as unknown[]) : [];
+  return {
+    headline: getStr((shape as any).headline || 'Match Summary'),
+    paragraph: getStr((shape as any).paragraph ?? (shape as any).one_paragraph ?? (shape as any).summary ?? ''),
+    bullets: bulletsRaw.map((b) => getStr(b)),
+  };
+}


### PR DESCRIPTION
This pull request introduces support for a "full" summary mode in the safe summarization API, allowing clients to request longer, less-clamped summaries. It updates the moderation and schema logic to handle larger content sizes when the `full` flag is set, and ensures that both the API and frontend components can utilize this feature.

**Full summary mode and API changes:**

* Added a `full` boolean option to the safe summarization API (`/api/safe-summarize`) and the `safeSummarize` client function, allowing requests for extended summaries. [[1]](diffhunk://#diff-d4dab273bd3ae7b34f78919c4c41548e03d93a3fe4e26c70474b07db64ab3bd3L1-R8) [[2]](diffhunk://#diff-16166f31b10a98a42daa2c3dd0d1b6a079aa2de2450ba90c2593b77f77c4d29cR16)
* Implemented the `coerceSummaryLoose` function in `summarySchema.ts` to coerce raw summary data without clamping, used when `full` mode is enabled.
* Updated moderation logic in `moderation.ts` to accept an optional `clamp` parameter, supporting larger content limits for headlines, paragraphs, and bullet lists when `full` mode is requested.

**Frontend integration:**

* Modified `MatchSummaryCard.tsx` to request summaries with `full: true`, enabling the display of longer summaries in the UI.

**Schema and content size adjustments:**

* Increased the paragraph length cap in the summary schema from 800 to 1000 characters for normal mode, and up to 10,000 characters for full mode. [[1]](diffhunk://#diff-c4e20e950e326054eb6173236a746603f3303c490a729fd5131dc51533c9cd37L11-R11) [[2]](diffhunk://#diff-d4dab273bd3ae7b34f78919c4c41548e03d93a3fe4e26c70474b07db64ab3bd3L41-R64)